### PR TITLE
Increase maximum exclusion fields

### DIFF
--- a/gui/src/main/java/io/github/santulator/gui/view/ExclusionFields.java
+++ b/gui/src/main/java/io/github/santulator/gui/view/ExclusionFields.java
@@ -19,7 +19,7 @@ import static io.github.santulator.gui.view.IconTool.icon;
 import static io.github.santulator.gui.view.ParticipantCell.CLASS_FIELD_EXCLUSIONS;
 
 public class ExclusionFields {
-    private static final int MAX_EXCLUSION_FIELDS = 5;
+    private static final int MAX_EXCLUSION_FIELDS = 9;
 
     private final TextField[] fields = IntStream.range(0, MAX_EXCLUSION_FIELDS)
         .mapToObj(this::prepareExclusionField)


### PR DESCRIPTION
Hi, thank you for this tool I use each year without missing a beat since 2019 for a group of ten Santa Clauses.
Aaaand yeah, of course I reach this year the limit of 5 exclusions maximum !

So here is a little fix so my own case will be handled until everyone has had a chance to offer a present to each other !

Feel free to do what you want with it :). Maybe allowing up to (number of participants - 1) exclusion could be a thing ?